### PR TITLE
Add configurable score to missed places

### DIFF
--- a/aura/analyzers/python/jinja.py
+++ b/aura/analyzers/python/jinja.py
@@ -41,7 +41,7 @@ class JinjaAnalyzer(base.NodeAnalyzerV2, ASTAnalyzer):
             hit = Detection(
                 detection_type="JinjaVulnerability",
                 message="Detected jinja environment with autoescaping explicitly disabled",
-                score=100,
+                score=config.get_score_or_default("jinja-disabled-autoescape", 100),
                 line_no=context.node.line_no,
                 signature=f"jinja#xss#{context.visitor.normalized_path}#{context.node.line_no}",
                 tags = {"vuln:jinja:disabled_autoescape"}
@@ -193,7 +193,7 @@ class JinjaTemplateVisitor(Visitor):
             hit = Detection(
                 detection_type="JinjaVulnerability",
                 message="Tainted input passed to sink in the jinja template",
-                score=100,
+                score=config.get_score_or_default("jinja-taint", 100),
                 line_no=lineno,
                 signature=f"jinja#taint_analysis#{str(self.location)}#{lineno}",
                 location=self.location.location,

--- a/aura/analyzers/python/sqli.py
+++ b/aura/analyzers/python/sqli.py
@@ -4,6 +4,7 @@ from .. import base
 from ..detections import Detection
 from .nodes import *
 from ...bases import ASTAnalyzer
+from ... import config
 
 
 SQL_REGEX = re.compile(
@@ -45,7 +46,7 @@ class SQLi(base.NodeAnalyzerV2, ASTAnalyzer):
 
         yield Detection(
             detection_type="SQLInjection",
-            score=50,
+            score=config.get_score_or_default("sqli-possible", 50),
             message="Possible SQL injection found",
             signature=f"vuln#{context.signature}",
             node = context.node,
@@ -72,7 +73,7 @@ class SQLi(base.NodeAnalyzerV2, ASTAnalyzer):
 
         yield Detection(
             detection_type="SQLInjection",
-            score=50,
+            score=config.get_score_or_default("sqli-possible", 50),
             message="Possible SQL injection found",
             signature=f"vuln#sqli#{context.signature}",
             node = context.node,

--- a/aura/analyzers/python/taint/base.py
+++ b/aura/analyzers/python/taint/base.py
@@ -5,6 +5,7 @@ from ..nodes import Taints, ASTNode, TaintLog, Context, NodeType, ReturnStmt
 from ...base import NodeAnalyzerV2
 from ...detections import Detection
 from ....bases import ASTAnalyzer
+from .... import config
 
 
 class TaintDetection(NodeAnalyzerV2, ASTAnalyzer):
@@ -17,7 +18,7 @@ class TaintDetection(NodeAnalyzerV2, ASTAnalyzer):
 
         return Detection(
             detection_type="TaintAnomaly",
-            score=10,
+            score=config.get_score_or_default("taint-anomaly", 10),
             message="Tainted input is passed to the sink",
             node=context.node,
             line_no=context.node.line_no,

--- a/aura/analyzers/setup.py
+++ b/aura/analyzers/setup.py
@@ -62,7 +62,7 @@ class SetupPy(NodeAnalyzerV2, ASTAnalyzer):
             ):
                 sig = Detection(
                     detection_type="SetupScript",
-                    score=100,
+                    score=config.get_score_or_default("setup-py-name-shadowing", 100),
                     message=f"Package '{parsed['name']}' is installed under different name: '{pkg}'",
                     signature=f"setup_analyzer#pkg_name_mismatch#{parsed['name']}#{pkg}",
                     tags = {"behavior:setup_py:name_shadowing"}
@@ -71,7 +71,7 @@ class SetupPy(NodeAnalyzerV2, ASTAnalyzer):
 
         main_sig = Detection(
             detection_type="SetupScript",
-            score=0,
+            score=config.get_score_or_default("setup-py-setup-script", 0),
             message="Setup script found", extra={"parsed": parsed},
             signature=f"setup_analyzer#setup_script#{context.visitor.normalized_path}#{context.node.line_no}",
             node=context.node
@@ -99,7 +99,7 @@ class SetupPy(NodeAnalyzerV2, ASTAnalyzer):
             if "behavior:code_execution" in x.tags:
                 sig = Detection(
                     detection_type="SetupScript",
-                    score=100,
+                    score=config.get_score_or_default("setup-py-code-exec", 100),
                     message="Code execution capabilities found in a setup.py script",
                     node=x.node,
                     line=x.line,
@@ -112,7 +112,7 @@ class SetupPy(NodeAnalyzerV2, ASTAnalyzer):
             if "behavior:network" in x.tags:
                 sig = Detection(
                     detection_type="SetupScript",
-                    score=100,
+                    score=config.get_score_or_default("setup-py-network", 100),
                     message="Found code with network communication capabilities in a setup.py script",
                     node=x.node,
                     line=x.line,
@@ -132,7 +132,7 @@ class SetupPy(NodeAnalyzerV2, ASTAnalyzer):
             if "install" in parsed["install_hooks"]:
                 sig = Detection(
                     detection_type="SetupScript",
-                    score=500,
+                    score=config.get_score_or_default("setup-py-install-hook", 500),
                     message="Setup script hooks to the `setup.py install` command.",
                     signature=f"setup_analyzer#install_hook#{context.visitor.normalized_path}#{context.node.line_no}",
                     node=context.node,

--- a/aura/data/aura_config.yaml
+++ b/aura/data/aura_config.yaml
@@ -303,6 +303,33 @@ score: &scores
   # Leaking PyPIrc credentials
   # leaking_pypirc: 100
 
+  # Package is installed with another name
+  # setup-py-name-shadowing: 100
+
+  # Found the setup script
+  # setup-py-setup-script: 0
+
+  # Code execution found in setup.py
+  # setup-py-code-exec: 100
+
+  # Network communication found in setup.py
+  # setup-py-network: 100
+
+  # Install hook found in setup.py
+  # setup-py-install-hook: 500
+
+  # Jinja: disabled autoescape
+  # jinja-disabled-autoescape: 100
+
+  # Jinja: tainted input passed to sink variable
+  # jinja-taint: 100
+
+  # Possible SQL injection
+  # sqli-possible: 50
+
+  # Tainted data passed to sink
+  # taint-anomaly: 10
+
 cache: &cache
   # Mode can be one of:
   # - "ask": ask if cache should be purged when running some commands (aura info, aura update ...)


### PR DESCRIPTION
Some analyzers missed getting the score from the
config file. It's now fixed.