### PR TITLE
Fix filtering and allow partial tags matching

### DIFF
--- a/aura/output/filtering.py
+++ b/aura/output/filtering.py
@@ -14,7 +14,7 @@ class FilterConfiguration:
         processed = []
         total_score: int = 0
 
-        compiled_tags = compile_filter_tags(self.tag_filters)
+        compiled_include, compiled_exclude = compile_filter_tags(self.tag_filters)
 
         for detection in sorted(detections):
             # Normalize tags
@@ -24,9 +24,13 @@ class FilterConfiguration:
             # norm is that informational results should have a score of 0
             if self.verbosity < 2 and detection.informational and detection.score == 0:
                 continue
-            elif not all(tag_filter(tags) for tag_filter in compiled_tags):
+            elif compiled_exclude and not all(tag_filter(tags) for tag_filter in compiled_exclude):
                 continue
-            elif self.verbosity < 3 and detection.name == "ASTParseError" and detection._metadata.get("source") == "blob":
+            elif compiled_include and not any(tag_filter(tags) for tag_filter in compiled_include):
+                continue
+            elif (
+                self.verbosity < 3 and detection.name == "ASTParseError" and detection._metadata.get("source") == "blob"
+            ):
                 continue
             else:
                 total_score += detection.score
@@ -42,18 +46,37 @@ def compile_filter_tags(tags: Iterable[str]) -> List[Callable[[Iterable[str]], b
     """
     compile input filter tags into an easy to use list of lambda's so the output hits can be filtered using map
     """
-    compiled = []
+    include_tags = []
+    exclude_tags = []
+
+    def include(tag):
+        def wrapper(x):
+            if tag[-1] == "*":
+                return any(y.startswith(tag[:-1]) for y in x)
+            else:
+                return tag in x
+
+        return wrapper
+
+    def exclude(tag):
+        def wrapper(x):
+            if tag[-1] == "*":
+                return not any(y.startswith(tag[:-1]) for y in x)
+            else:
+                return tag not in x
+
+        return wrapper
 
     for t in tags:
         # normalize tags to lowercase with `-` replaced to `_`
-        t = t.strip().lower().replace('-', '_')
+        t = t.strip().lower().replace("-", "_")
 
         if not t:
             continue
 
         if t.startswith("!"):  # It a tag is prefixed with `!` then it means to exclude findings with such tag
-            compiled.append(lambda x: t[1:] not in x)
+            exclude_tags.append(exclude(t[1:]))
         else:
-            compiled.append(lambda x: t in x)
+            include_tags.append(include(t))
 
-    return compiled
+    return include_tags, exclude_tags


### PR DESCRIPTION
Previous implementation of filtering had two issues:
1. as lambda functions do not create their own variable scopes, only the last filter was ever used;
2. selecting tags (after fixing 1) required all of them to be presented in a finding to include it.
Tests weren't verifying the number of returned detections, and thous, this wasn't caught.

In addition, this commit introduces the possibility of partial matching filters, using e.g., syntax `!vuln:*` to exclude all vulnerabilities.